### PR TITLE
Update robots.txt to block PDF and Keynote files.

### DIFF
--- a/pagerduty/robots.txt
+++ b/pagerduty/robots.txt
@@ -1,3 +1,8 @@
-# Allow everything
+# Allow everything by default.
 User-agent: *
 Disallow:
+
+# Disallow some assets for robots.
+User-agent:  *
+Disallow: /assets/*.pdf
+Disallow: /assets/*.key


### PR DESCRIPTION
A not-insignificant amount of bandwidth is used by robots downloading the large PDF and Keynote assets on our sites. This will ask them nicely to not do that.